### PR TITLE
Remove DNS synthesis recommendation per Mark Andrews objection

### DIFF
--- a/draft-ietf-dnsop-3901bis.xml
+++ b/draft-ietf-dnsop-3901bis.xml
@@ -364,7 +364,6 @@
                 <t>
                     Hence, when a host running a stub DNS resolver receives addresses for IPv4 and IPv6 recursive DNS resolver to use, it <bcp14>MAY</bcp14> prioritize reachable IPv6 recursive DNS resolvers.
                     When available, a stub DNS resolver <bcp14>MAY</bcp14> prefer using non-synthesized IPv6 addresses, instead of synthesized IPv6 addresses using NAT64 connectivity discovered through PREF64 <xref target="RFC8781"/> or DNS64 <xref target="RFC7050"/>.
-                    If a stub DNS resolver runs in an IPv6-mostly network <xref target="RFC9313"/>, and the stub DNS resolver is aware of the used PREF64 <xref target="RFC6146"/>, it <bcp14>MAY</bcp14> synthesize mapped IPv6 addresses for remote authoritative DNS servers directly, instead of relying on the socket translation layer of the operating system.
                 </t>
             </section>
         </section>


### PR DESCRIPTION
## Summary

This PR removes the problematic text suggesting that stub DNS resolvers MAY synthesize IPv6 addresses.

## Background

Mark Andrews strongly objected to DNS-level address synthesis in his mailing list response:
https://www.mail-archive.com/dnsop@ietf.org/msg31222.html

His key argument: DNS is an application layer protocol that deals with IP address literals and should not perform network layer address transformations. Address synthesis should be handled at the OS/kernel level via CLAT mechanisms (RFC 6877).

## Changes

- Removed the sentence from Section 2.3.3 that stated stub resolvers 'MAY synthesize mapped IPv6 addresses for remote authoritative DNS servers directly'
- Kept the text about preferring non-synthesized addresses when available

## Impact

This addresses a blocking objection that could prevent the document from progressing to WGLC.

Fixes: Address synthesis objection from ML discussion