### PR TITLE
Fix XML syntax error in author element

### DIFF
--- a/draft-ietf-dnsop-3901bis.xml
+++ b/draft-ietf-dnsop-3901bis.xml
@@ -12,7 +12,7 @@
     <front>
         <title abbrev="3901bis">DNS IPv6 Transport Operational Guidelines</title>
         <seriesInfo name="Internet-Draft" status="standard" value="draft-ietf-dnsop-3901bis-latest"/>
-        <author fullname="Momoka Yamamoto" initials="M." surname="Yamamoto"
+        <author fullname="Momoka Yamamoto" initials="M." surname="Yamamoto">
             <organization>WIDE Project</organization>
             <address>
                 <email>momoka.my6@gmail.com</email>


### PR DESCRIPTION
## Summary

This PR fixes a simple XML syntax error in the author element that was causing XML parsing failures.

## Change

The author element on line 15 was missing a closing angle bracket (`>`).

**Before:**
```xml
<author fullname="Momoka Yamamoto" initials="M." surname="Yamamoto"
```

**After:**
```xml
<author fullname="Momoka Yamamoto" initials="M." surname="Yamamoto">
```

## Test Plan
- [x] XML validates successfully with `xmllint`
- [x] No other changes included