### PR TITLE
Added comment on max. of three resolvers.

### DIFF
--- a/draft-ietf-dnsop-3901bis.xml
+++ b/draft-ietf-dnsop-3901bis.xml
@@ -366,6 +366,9 @@
                     When available, a stub DNS resolver <bcp14>MAY</bcp14> prefer using non-synthesized IPv6 addresses, instead of synthesized IPv6 addresses using NAT64 connectivity discovered through PREF64 <xref target="RFC8781"/> or DNS64 <xref target="RFC7050"/>.
                     If a stub DNS resolver runs in an IPv6-mostly network <xref target="RFC9313"/>, and the stub DNS resolver is aware of the used PREF64 <xref target="RFC6146"/>, it <bcp14>MAY</bcp14> synthesize mapped IPv6 addresses for remote authoritative DNS servers directly, instead of relying on the socket translation layer of the operating system.
                 </t>
+                <t>
+                    When providing multiple possible DNS servers to stub resolvers, operators <bcp14>SHOULD</bcp14> consider that various implementations can only configure a small set of possible DNS resolvers, e.g., only up to three for libc, and additional resolvers provided may be ignored by clients.
+                </t>
             </section>
         </section>
         <section anchor="security-considerations">


### PR DESCRIPTION
During dnsop at 124, there was a comment that some implementations only support up to three NS (libc most prominently). It was recommended to at least note this issue in the document. This PR implements that.